### PR TITLE
laravel version:6.18.3, array_get 方法找不到

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,10 @@
     "autoload": {
         "psr-4": {
             "SmallRuralDog\\LightBox\\": "src/"
-        }
+        },
+        "files": [
+            "src/functions.php"
+        ]
     },
     "extra": {
         "laravel": {

--- a/src/functions.php
+++ b/src/functions.php
@@ -1,0 +1,9 @@
+<?php
+
+use Illuminate\Support\Arr;
+
+if(!function_exists('array_get')){
+    function array_get($array, $key, $default = null){
+        return Arr::get($array, $key, $default = null);
+    }
+}


### PR DESCRIPTION
laravel version:6.18.3, array_get 方法为定义